### PR TITLE
feat: add more endpoints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
+        with:
+          release-type: ruby
+          package-name: prizepicks
+          bump-minor-pre-major: true
+          version-file: "lib/prizepicks/version.rb"
+      # Checkout code if release was created
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.release_created }}
+      # Setup ruby if a release was created
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.0
+        if: ${{ steps.release.outputs.release_created }}
+      # Bundle install
+      - run: bundle install
+        if: ${{ steps.release.outputs.release_created }}
+      # Publish
+      - name: publish gem
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+        if: ${{ steps.release.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 PrizePicks Client
 =================
 
+[![Gem Version](https://badge.fury.io/rb/prizepicks.svg)](https://badge.fury.io/rb/prizepicks)
+[![Run tests](https://github.com/troyizzle/prizepicks/actions/workflows/main.yml/badge.svg)](https://github.com/troyizzle/prizepicks/actions/workflows/main.yml)
+
 A client for PrizePicks API.
 
 ## Installation
@@ -11,10 +14,12 @@ gem 'prizepicks'
 ```
 
 Add then execute:
-$ bundle install
+
+`$ bundle install`
 
 Or install it yourself as:
-$ gem install prizepicks
+
+`$ gem install prizepicks`
 
 ## Usage
 ### Currently this only has fetching /entries

--- a/lib/prizepicks.rb
+++ b/lib/prizepicks.rb
@@ -1,17 +1,26 @@
 # frozen_string_literal: true
-
-require 'prizepicks/version'
-require 'prizepicks/config'
-
 require 'faraday'
 require 'faraday-cookie_jar'
-
+require 'prizepicks/version'
+# require 'prizepicks/config'
 require_relative 'prizepicks/faraday/connection'
 require_relative 'prizepicks/faraday/request'
 require_relative 'prizepicks/api/endpoints'
-require_relative 'prizepicks/client'
+# require_relative 'prizepicks/client'
 
-# module Prizepicks
-#   class Error < StandardError; end
-#   # Your code goes here...
-# end
+module PrizePicks
+  autoload :Client, 'prizepicks/client'
+  autoload :Collection, 'prizepicks/collection'
+  autoload :Config, 'prizepicks/config'
+  autoload :Error, 'prizepicks/error'
+
+  # Responses
+  autoload :Responses, 'prizepicks/api/responses'
+
+  # Object
+  autoload :Base, 'prizepicks/objects/base'
+  autoload :Entry, 'prizepicks/objects/entry'
+  autoload :League, 'prizepicks/objects/league'
+  autoload :Projection, 'prizepicks/objects/projection'
+  autoload :User, 'prizepicks/objects/user'
+end

--- a/lib/prizepicks/api/endpoints.rb
+++ b/lib/prizepicks/api/endpoints.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'endpoints/entries'
+require_relative 'endpoints/leagues'
+require_relative 'endpoints/projections'
 require_relative 'endpoints/sign_in'
 
 module PrizePicks
   module Api
     module Endpoints
       include Entries
+      include Leagues
+      include Projections
       include SignIn
     end
   end

--- a/lib/prizepicks/api/endpoints/entries.rb
+++ b/lib/prizepicks/api/endpoints/entries.rb
@@ -3,8 +3,14 @@ module PrizePicks
   module Api
     module Endpoints
       module Entries
+        ENDPOINT = '/v1/entries'
+
         def entries(options = {})
-          request(:get, 'v1/entries', options)
+          raise ArgumentError, 'email is required' unless @email
+          raise ArgumentError, 'password is required' unless @password
+
+          resp = request(:get, ENDPOINT, options)
+          Collection.from_response(resp, type: Entry)
         end
       end
     end

--- a/lib/prizepicks/api/endpoints/leagues.rb
+++ b/lib/prizepicks/api/endpoints/leagues.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module PrizePicks
+  module Api
+    module Endpoints
+      module Leagues
+        ENDPOINT = '/v1/leagues'
+
+        def leagues(options = {})
+          resp = request(:get, ENDPOINT, options)
+          Collection.from_response(resp, type: League)
+        end
+      end
+    end
+  end
+end

--- a/lib/prizepicks/api/endpoints/projections.rb
+++ b/lib/prizepicks/api/endpoints/projections.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module PrizePicks
+  module Api
+    module Endpoints
+      module Projections
+        ENDPOINT = '/v1/projections'
+
+        def projections(options = {})
+          resp = request(:get, ENDPOINT, options)
+          Collection.from_response(resp, type: Projection)
+        end
+      end
+    end
+  end
+end

--- a/lib/prizepicks/api/endpoints/sign_in.rb
+++ b/lib/prizepicks/api/endpoints/sign_in.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
+
 module PrizePicks
   module Api
     module Endpoints
       module SignIn
+        ENDPOINT = '/users/sign_in'
+
         def sign_in
-          request(:post, '/users/sign_in', {
+          resp = request(:post, ENDPOINT, {
             user: {
               email: @email,
               password: @password,
             },
           })
+
+          User.new(resp)
         end
       end
     end

--- a/lib/prizepicks/api/responses/user.rb
+++ b/lib/prizepicks/api/responses/user.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module PrizePicks
+  module Api
+    module Responses
+      class User < OpenStruct
+        def initialize(attributes)
+          super to_obstruct(attributes)
+        end
+
+        def to_obstruct(_attributes)
+          case obj
+          when Hash
+            OpenStruct.new(obj.transform_values { |val| to_obstruct(val) })
+          when Array
+            obj.map { |o| to_obstruct(o) }
+          else
+            obj
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/prizepicks/client.rb
+++ b/lib/prizepicks/client.rb
@@ -6,14 +6,16 @@ module PrizePicks
     include Api::Endpoints
 
     attr_accessor(*Config::ATTRIBUTES)
+    attr_reader :adapter
 
     def initialize(options = {})
       PrizePicks::Config::ATTRIBUTES.each do |key|
         send("#{key}=", options.fetch(key, PrizePicks.config.send(key)))
       end
 
-      raise ArgumentError, 'Missing :email' unless email
-      raise ArgumentError, 'Missing :password' unless password
+      # For testing
+      @stubs = options[:stubs] || nil
+      @adapter = options[:adapter] || nil
     end
   end
 end

--- a/lib/prizepicks/collection.rb
+++ b/lib/prizepicks/collection.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module PrizePicks
+  class Collection
+    attr_reader :data, :total_pages, :current_page
+
+    def self.from_response(response, type:)
+      new(
+        data: response['data'].map { |attrs| type.new(attrs) },
+        current_page: response.dig('meta', 'current_page'),
+        total_pages: response.dig('meta', 'total_pages')
+      )
+    end
+
+    def initialize(data:, current_page:, total_pages:)
+      @data = data
+      @current_page = current_page
+      @total_pages = total_pages
+    end
+  end
+end

--- a/lib/prizepicks/error.rb
+++ b/lib/prizepicks/error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module PrizePicks
+  class Error < StandardError; end
+end

--- a/lib/prizepicks/faraday/connection.rb
+++ b/lib/prizepicks/faraday/connection.rb
@@ -10,7 +10,7 @@ module PrizePicks
           faraday.response :json
           faraday.use :cookie_jar
           faraday.response :raise_error
-          faraday.adapter ::Faraday.default_adapter
+          faraday.adapter adapter, @stubs
         end
       end
     end

--- a/lib/prizepicks/objects/base.rb
+++ b/lib/prizepicks/objects/base.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'ostruct'
+
+module PrizePicks
+  class Base < OpenStruct
+    def initialize(resp)
+      @resp = resp
+      super to_obstruct(resp.dig('data', 'attributes'))
+    end
+
+    def data
+      @resp['data']
+    end
+
+    def to_obstruct(obj)
+      case obj
+      when Hash
+        OpenStruct.new(obj.transform_values { |val| to_obstruct(val) })
+      when Array
+        obj.map { |o| to_obstruct(o) }
+      else
+        obj
+      end
+    end
+  end
+end

--- a/lib/prizepicks/objects/entry.rb
+++ b/lib/prizepicks/objects/entry.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module PrizePicks
+  class Entry < Base
+  end
+end

--- a/lib/prizepicks/objects/league.rb
+++ b/lib/prizepicks/objects/league.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module PrizePicks
+  class League < Base
+  end
+end

--- a/lib/prizepicks/objects/projection.rb
+++ b/lib/prizepicks/objects/projection.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module PrizePicks
+  class Projection < Base
+  end
+end

--- a/lib/prizepicks/objects/user.rb
+++ b/lib/prizepicks/objects/user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module PrizePicks
+  class User < Base
+  end
+end

--- a/prizepicks.gemspec
+++ b/prizepicks.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
-  # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/sig/prizepicks.rbs
+++ b/sig/prizepicks.rbs
@@ -1,4 +1,4 @@
-module Prizepicks
+module PrizePicks
   VERSION: String
   # See the writing guide of rbs: https://github.com/ruby/rbs#guides
 end

--- a/test/fixtures/entries.json
+++ b/test/fixtures/entries.json
@@ -1,0 +1,194 @@
+{
+  "data": [
+    {
+      "type": "new_wager",
+      "id": "134928677",
+      "attributes": {
+        "amount_bet_cents": 2000,
+        "amount_to_win_cents": 6000,
+        "amount_won_cents": 0,
+        "code": null,
+        "correlated_entry": false,
+        "created_at": "2023-02-16T16:38:38-05:00",
+        "eligible_for_refund": false,
+        "is_gift": false,
+        "parlay_count": 2,
+        "payout_multipliers": {
+          "0": 3
+        },
+        "payouts": {
+          "2": {
+            "amount": 6000,
+            "multiplier": 3
+          }
+        },
+        "pick_protection": false,
+        "promo_tag": false,
+        "promotion_id": null,
+        "refund_allowed_until": null,
+        "result": "pending",
+        "reverted_payouts": {
+          "2": {
+            "amount": 6000,
+            "multiplier": 3
+          }
+        },
+        "ruleset_id": 1,
+        "sport": "NBA1H",
+        "updated_at": "2023-02-16T16:38:38-05:00",
+        "user_id": 1224768,
+        "uuid": null
+      },
+      "relationships": {
+        "predictions": {
+          "data": [
+            {
+              "type": "prediction",
+              "id": "520195535"
+            },
+            {
+              "type": "prediction",
+              "id": "520195536"
+            }
+          ]
+        },
+        "promotion": {
+          "data": null
+        }
+      }
+    },
+    {
+      "type": "new_wager",
+      "id": "134921060",
+      "attributes": {
+        "amount_bet_cents": 500,
+        "amount_to_win_cents": 12500,
+        "amount_won_cents": 0,
+        "code": null,
+        "correlated_entry": false,
+        "created_at": "2023-02-16T16:30:32-05:00",
+        "eligible_for_refund": false,
+        "is_gift": false,
+        "parlay_count": 6,
+        "payout_multipliers": {
+          "0": 25,
+          "1": 2,
+          "2": 0.4
+        },
+        "payouts": {
+          "4": {
+            "amount": 200,
+            "multiplier": 0.4
+          },
+          "5": {
+            "amount": 1000,
+            "multiplier": 2
+          },
+          "6": {
+            "amount": 12500,
+            "multiplier": 25
+          }
+        },
+        "pick_protection": true,
+        "promo_tag": false,
+        "promotion_id": null,
+        "refund_allowed_until": null,
+        "result": "pending",
+        "reverted_payouts": {
+          "3": {
+            "amount": 200,
+            "multiplier": 0.4
+          },
+          "4": {
+            "amount": 1000,
+            "multiplier": 2
+          },
+          "5": {
+            "amount": 5000,
+            "multiplier": 10
+          }
+        },
+        "ruleset_id": 1,
+        "sport": "MIXED: NBA,NBA1H",
+        "updated_at": "2023-02-16T16:30:32-05:00",
+        "user_id": 1224768,
+        "uuid": null
+      },
+      "relationships": {
+        "predictions": {
+          "data": [
+            {
+              "type": "prediction",
+              "id": "520165408"
+            },
+            {
+              "type": "prediction",
+              "id": "520165409"
+            },
+            {
+              "type": "prediction",
+              "id": "520165410"
+            },
+            {
+              "type": "prediction",
+              "id": "520165411"
+            },
+            {
+              "type": "prediction",
+              "id": "520165412"
+            },
+            {
+              "type": "prediction",
+              "id": "520165413"
+            }
+          ]
+        },
+        "promotion": {
+          "data": null
+        }
+      }
+    }
+  ],
+  "included": [
+     {
+      "type": "score",
+      "id": "997198",
+      "attributes": {
+        "details": {
+          "FantasyScore": 10.5,
+          "ReceivingTargets": 6,
+          "ReceivingYards": 55,
+          "Receptions": 5,
+          "UpdatedAt": "Feb 12 2023 at 09:22PM ET"
+        },
+        "is_auto_settled": true,
+        "is_final": true,
+        "is_off_the_board": false,
+        "score": 6,
+        "unders_win_dnp": false
+      }
+    },
+    {
+      "type": "new_player",
+      "id": "59515",
+      "attributes": {
+        "image_url": "https://static.prizepicks.com/images/players/nhl/Evander_Kane_4354082b-0f24-11e2-8525-18a905767e44.webp",
+        "league": "NHL",
+        "league_id": 8,
+        "market": "Edmonton",
+        "name": "Evander Kane",
+        "position": "F",
+        "team": "EDM",
+        "team_name": "Oilers"
+      },
+      "relationships": {
+        "league": {
+          "data": {
+            "type": "league",
+            "id": "8"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/entry.json
+++ b/test/fixtures/entry.json
@@ -1,0 +1,57 @@
+{
+  "type": "new_wager",
+  "id": "134928677",
+  "attributes": {
+    "amount_bet_cents": 2000,
+    "amount_to_win_cents": 6000,
+    "amount_won_cents": 0,
+    "code": null,
+    "correlated_entry": false,
+    "created_at": "2023-02-16T16:38:38-05:00",
+    "eligible_for_refund": false,
+    "is_gift": false,
+    "parlay_count": 2,
+    "payout_multipliers": {
+      "0": 3
+    },
+    "payouts": {
+      "2": {
+        "amount": 6000,
+        "multiplier": 3
+      }
+    },
+    "pick_protection": false,
+    "promo_tag": false,
+    "promotion_id": null,
+    "refund_allowed_until": null,
+    "result": "pending",
+    "reverted_payouts": {
+      "2": {
+        "amount": 6000,
+        "multiplier": 3
+      }
+    },
+    "ruleset_id": 1,
+    "sport": "NBA1H",
+    "updated_at": "2023-02-16T16:38:38-05:00",
+    "user_id": 1224768,
+    "uuid": null
+  },
+  "relationships": {
+    "predictions": {
+      "data": [
+        {
+          "type": "prediction",
+          "id": "520195535"
+        },
+        {
+          "type": "prediction",
+          "id": "520195536"
+        }
+      ]
+    },
+    "promotion": {
+      "data": null
+    }
+  }
+}

--- a/test/fixtures/leagues.json
+++ b/test/fixtures/leagues.json
@@ -1,0 +1,70 @@
+{
+  "data": [
+    {
+      "id": "238",
+      "type": "league",
+      "attributes": {
+        "name": "AUSNBL",
+        "rank": 0,
+        "active": true,
+        "created_at": "2022-10-19T13:08:08.276-04:00",
+        "updated_at": "2023-02-17T00:08:09.351-05:00",
+        "icon": "basketball",
+        "image_url": "https://static.prizepicks.com/images/leagues/basketball.svg",
+        "last_five_games_enabled": false,
+        "projections_count": 0
+      },
+      "relationships": {
+        "projection_filters": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "9",
+      "type": "league",
+      "attributes": {
+        "name": "NFL",
+        "rank": 0,
+        "active": true,
+        "created_at": "2018-07-19T13:26:11.622-04:00",
+        "updated_at": "2023-02-11T21:00:36.023-05:00",
+        "icon": "football",
+        "image_url": "https://static.prizepicks.com/images/leagues/football.svg",
+        "last_five_games_enabled": true,
+        "projections_count": 0
+      },
+      "relationships": {
+        "projection_filters": {
+          "data": []
+        }
+      }
+    }
+  ],
+  "included": [
+   {
+      "id": "2",
+      "type": "projection_filter",
+      "attributes": {
+        "name": "Single Stat",
+        "type": "ProjectionType",
+        "rank": null,
+        "created_at": "2021-01-18T18:08:09.323-05:00",
+        "updated_at": "2021-01-18T18:08:09.323-05:00",
+        "lfg_ignored_leagues": null
+      }
+    },
+    {
+      "id": "133",
+      "type": "projection_filter",
+      "attributes": {
+        "name": "Hole 11 Shots",
+        "type": "StatType",
+        "rank": 17,
+        "created_at": "2022-02-18T20:01:27.270-05:00",
+        "updated_at": "2022-02-25T08:23:59.224-05:00",
+        "lfg_ignored_leagues": null
+      }
+    }
+  ]
+}

--- a/test/fixtures/projections.json
+++ b/test/fixtures/projections.json
@@ -1,0 +1,136 @@
+{
+  "data": [
+    {
+      "type": "projection",
+      "id": "1078856",
+      "attributes": {
+        "board_time": "2023-02-17T00:16:00-05:00",
+        "custom_image": null,
+        "description": "22 Games Remaining",
+        "discount_percentage": 96,
+        "end_time": "2023-02-23T20:30:00-05:00",
+        "flash_sale_line_score": 0.5,
+        "is_promo": true,
+        "line_score": 15.5,
+        "projection_type": "Single Stat",
+        "rank": 0,
+        "refundable": true,
+        "start_time": "2023-02-23T20:30:00-05:00",
+        "stat_type": "30+ Points Games",
+        "status": "pre_game",
+        "tv_channel": null,
+        "updated_at": "2023-02-17T11:09:52-05:00"
+      },
+      "relationships": {
+        "duration": {
+          "data": null
+        },
+        "league": {
+          "data": {
+            "type": "league",
+            "id": "188"
+          }
+        },
+        "new_player": {
+          "data": {
+            "type": "new_player",
+            "id": "123792"
+          }
+        },
+        "projection_type": {
+          "data": {
+            "type": "projection_type",
+            "id": "2"
+          }
+        },
+        "stat_type": {
+          "data": {
+            "type": "stat_type",
+            "id": "363"
+          }
+        }
+      }
+    },
+    {
+      "type": "projection",
+      "id": "1078584",
+      "attributes": {
+        "board_time": "2023-02-16T22:10:00-05:00",
+        "custom_image": null,
+        "description": "25 Games Remaining",
+        "end_time": null,
+        "flash_sale_line_score": null,
+        "is_promo": false,
+        "line_score": 15.5,
+        "projection_type": "Single Stat",
+        "rank": 1,
+        "refundable": true,
+        "start_time": "2023-02-20T12:15:00-05:00",
+        "stat_type": "10+ Assists Games",
+        "status": "pre_game",
+        "tv_channel": null,
+        "updated_at": "2023-02-16T22:16:14-05:00"
+      },
+      "relationships": {
+        "duration": {
+          "data": null
+        },
+        "league": {
+          "data": {
+            "type": "league",
+            "id": "188"
+          }
+        },
+        "new_player": {
+          "data": {
+            "type": "new_player",
+            "id": "60341"
+          }
+        },
+        "projection_type": {
+          "data": {
+            "type": "projection_type",
+            "id": "2"
+          }
+        },
+        "stat_type": {
+          "data": {
+            "type": "stat_type",
+            "id": "158"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "new_player",
+      "id": "47022",
+      "attributes": {
+        "image_url": "https://s3-us-west-2.amazonaws.com/static.fantasydata.com/headshots/soc/low-res/90027124.png",
+        "league": "SOCCER",
+        "league_id": 82,
+        "market": null,
+        "name": "Eric Maxim Choupo-Moting",
+        "position": "F",
+        "team": "Bayern München",
+        "team_name": null
+      },
+      "relationships": {
+        "league": {
+          "data": {
+            "type": "league",
+            "id": "82"
+          }
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": "api.prizepicks.com/projections?per_page=250&single_stat=true"
+  },
+  "meta": {
+    "current_page": 1,
+    "total_pages": 1
+  }
+}

--- a/test/fixtures/user.json
+++ b/test/fixtures/user.json
@@ -1,0 +1,62 @@
+{
+  "data": {
+    "id": "ceef0a4d-a09f-430f-b586-b95df14db8e5",
+    "type": "user",
+    "attributes": {
+      "email": "example@example.com",
+      "first_name": "John",
+      "last_name": "Doe",
+      "full_name": "John Doe",
+      "address": "123 Anywhere St",
+      "postal_code": "12345",
+      "city": "Rock",
+      "state": "NY",
+      "country_code": "US",
+      "role": null,
+      "phone_number": null,
+      "has_confirmed_phone_number": null,
+      "promo": 0.0,
+      "number_of_entries": 112,
+      "amount_won": 1967,
+      "verified": true,
+      "date_of_birth": "2001-01-01",
+      "push_notification_token": "dlFqFctCD6rm9xcvw0CiaAfv9uewEzZS",
+      "withdrawable_credit": 0.0,
+      "uid": null,
+      "provider": null,
+      "tourney_picks": 0,
+      "credit": 29.0,
+      "reward_picks": 0,
+      "notifications": false,
+      "invite_code": null,
+      "is_rotogrinders": null,
+      "referral_code": "AL-HEODACB",
+      "entries_won": 38,
+      "deposited_amount": 325.0,
+      "created_at": "2022-08-02T20:54:28.004-04:00",
+      "updated_at": "2023-02-17T15:05:47.924-05:00",
+      "chat_hash": "04cbf0607d09572352166d036de2c15604cbf0607d09572352166d036de2c156",
+      "idology_validation_state": "passed",
+      "confirmed_at": "2022-08-02T23:14:59.045-04:00",
+      "otp_status": "disabled",
+      "verification_image_reviewed": false,
+      "needs_tid": null,
+      "tid_validation": 0,
+      "last_deposit_at": "2023-02-14T18:55:01.919-05:00",
+      "default_entry_amount": null,
+      "default_entry_type": null,
+      "device_vibration": true,
+      "validation_provider": "idology",
+      "validation_state": "passed",
+      "show_balance": true,
+      "verification_image": null,
+      "terms_accepted": true
+    },
+    "relationships": {
+      "free_entries": {
+        "data": []
+      }
+    }
+  },
+  "included": []
+}

--- a/test/prizepicks/api/endpoints/test_entries.rb
+++ b/test/prizepicks/api/endpoints/test_entries.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module PrizePicks
+  module Api
+    module Endpoints
+      class TestEntries < MiniTest::Test
+        def test_entries_endpoint
+          assert_equal '/v1/entries', PrizePicks::Api::Endpoints::Entries::ENDPOINT
+        end
+
+        def test_entries_will_raise_error_if_not_signed_in
+          client = init_client
+          assert_raises ArgumentError do
+            client.entries
+          end
+        end
+
+        def test_entries
+          stub = stub_request(PrizePicks::Api::Endpoints::Entries::ENDPOINT,
+                              response: stub_response(fixture: 'entries'))
+          client = init_client(email: 'fake@fake.com', password: 'fake123!',
+                               stub: stub)
+          resp = client.entries
+          assert_equal PrizePicks::Collection, resp.class
+          assert_equal PrizePicks::Entry, resp.data.first.class
+        end
+      end
+    end
+  end
+end

--- a/test/prizepicks/api/endpoints/test_leagues.rb
+++ b/test/prizepicks/api/endpoints/test_leagues.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module PrizePicks
+  module Api
+    module Endpoints
+      class TestLeagues < MiniTest::Test
+        def test_leagues_endpoint
+          assert_equal '/v1/leagues', PrizePicks::Api::Endpoints::Leagues::ENDPOINT
+        end
+
+        def test_entries
+          stub = stub_request(PrizePicks::Api::Endpoints::Leagues::ENDPOINT,
+                              response: stub_response(fixture: 'leagues'))
+          client = init_client(stub: stub)
+          resp = client.leagues
+          assert_equal PrizePicks::Collection, resp.class
+          assert_equal PrizePicks::League, resp.data.first.class
+        end
+      end
+    end
+  end
+end

--- a/test/prizepicks/api/endpoints/test_projections.rb
+++ b/test/prizepicks/api/endpoints/test_projections.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module PrizePicks
+  module Api
+    module Endpoints
+      class TestProjections < MiniTest::Test
+        def test_projections_endpoint
+          assert_equal '/v1/projections', PrizePicks::Api::Endpoints::Projections::ENDPOINT
+        end
+
+        def test_projections
+          stub = stub_request(PrizePicks::Api::Endpoints::Projections::ENDPOINT,
+                              response: stub_response(fixture: 'projections'))
+          client = init_client(stub: stub)
+          resp = client.projections
+          assert_equal PrizePicks::Collection, resp.class
+          assert_equal PrizePicks::Projection, resp.data.first.class
+          assert_equal 1, resp.total_pages
+          assert_equal 1, resp.current_page
+        end
+      end
+    end
+  end
+end

--- a/test/prizepicks/api/endpoints/test_sign_in.rb
+++ b/test/prizepicks/api/endpoints/test_sign_in.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module PrizePicks
+  module Api
+    module Endpoints
+      class TestSignIn < MiniTest::Test
+        # rubocop:disable Metrics/MethodLength
+        def test_sign_in
+          stub = stub_request(PrizePicks::Api::Endpoints::SignIn::ENDPOINT,
+                              method: :post,
+                              response: stub_response(fixture: 'user'),
+                              body: {
+                                user: {
+                                  email: 'fake@fake.com', password: 'fake123!'
+                                },
+                              })
+          client = init_client(email: 'fake@fake.com', password: 'fake123!',
+                               stub: stub)
+          resp = client.sign_in
+          assert_equal PrizePicks::User, resp.class
+          assert_equal 'example@example.com', resp.email
+        end
+        # rubocop:enable Metrics/MethodLength
+      end
+    end
+  end
+end

--- a/test/prizepicks/objects/test_user.rb
+++ b/test/prizepicks/objects/test_user.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module PrizePicks
+  class TestUser < MiniTest::Test
+    def test_user
+      # assert_equal "hello", PrizePicks::User.new({ foo: 'bar'}).hello
+    end
+  end
+end

--- a/test/prizepicks/test_client.rb
+++ b/test/prizepicks/test_client.rb
@@ -3,16 +3,22 @@ require 'test_helper'
 
 module PrizePicks
   class TestClient < MiniTest::Test
-    def test_client_setup_raises_error_without_email
-      assert_raises ArgumentError do
-        init_client(password: 'foobar')
-      end
-    end
+    # def test_client_setup_raises_error_without_email
+    #   assert_raises ArgumentError do
+    #     init_client(password: 'foobar')
+    #   end
+    # end
+    #
+    # def test_client_setup_raises_error_without_password
+    #   assert_raises ArgumentError do
+    #     init_client(email: 'foo@foo.com')
+    #   end
+    # end
 
-    def test_client_setup_raises_error_without_password
-      assert_raises ArgumentError do
-        init_client(email: 'foo@foo.com')
-      end
+    def test_email
+      client = init_client(email: 'foo@foo.com', password: 'foobar')
+      assert_equal 'foo@foo.com', client.email
+      assert_equal 'foobar', client.password
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,9 +2,28 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'prizepicks'
-
 require 'minitest/autorun'
+require 'faraday'
+require 'json'
+
+module MiniTest
+  class Test
+    def stub_request(path, response:, method: :get, body: {})
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        args = [method, "https://api.prizepicks.com#{path}"]
+        args << body.to_json if %i[post put patch].include?(method)
+        stub.send(*args) { |_env| response }
+      end
+    end
+
+    def stub_response(fixture:, status: 200, headers: { 'Content-Type' => 'application/json' })
+      [status, headers, File.read("test/fixtures/#{fixture}.json")]
+    end
+  end
+end
 
 def init_client(opts = {})
+  opts[:adapter] = :test
+  opts[:stubs] = opts[:stub]
   PrizePicks::Client.new(opts)
 end


### PR DESCRIPTION
* Add a new endpoint for `Projections`
* Add a new endpoint for `Leagues`
* Responses now return an object with the data mapped
* Add test coverage