### PR TITLE
fix: entry fixture was incorrect

### DIFF
--- a/test/fixtures/entry.json
+++ b/test/fixtures/entry.json
@@ -1,57 +1,60 @@
 {
-  "type": "new_wager",
-  "id": "134928677",
-  "attributes": {
-    "amount_bet_cents": 2000,
-    "amount_to_win_cents": 6000,
-    "amount_won_cents": 0,
-    "code": null,
-    "correlated_entry": false,
-    "created_at": "2023-02-16T16:38:38-05:00",
-    "eligible_for_refund": false,
-    "is_gift": false,
-    "parlay_count": 2,
-    "payout_multipliers": {
-      "0": 3
-    },
-    "payouts": {
-      "2": {
-        "amount": 6000,
-        "multiplier": 3
-      }
-    },
-    "pick_protection": false,
-    "promo_tag": false,
-    "promotion_id": null,
-    "refund_allowed_until": null,
-    "result": "pending",
-    "reverted_payouts": {
-      "2": {
-        "amount": 6000,
-        "multiplier": 3
-      }
-    },
-    "ruleset_id": 1,
-    "sport": "NBA1H",
-    "updated_at": "2023-02-16T16:38:38-05:00",
-    "user_id": 1224768,
-    "uuid": null
-  },
-  "relationships": {
-    "predictions": {
-      "data": [
-        {
-          "type": "prediction",
-          "id": "520195535"
-        },
-        {
-          "type": "prediction",
-          "id": "520195536"
+  "data": {
+    "type": "new_wager",
+    "id": "134928677",
+    "attributes": {
+      "amount_bet_cents": 2000,
+      "amount_to_win_cents": 6000,
+      "amount_won_cents": 0,
+      "code": null,
+      "correlated_entry": false,
+      "created_at": "2023-02-16T16:38:38-05:00",
+      "eligible_for_refund": false,
+      "is_gift": false,
+      "parlay_count": 2,
+      "payout_multipliers": {
+        "0": 3
+      },
+      "payouts": {
+        "2": {
+          "amount": 6000,
+          "multiplier": 3
         }
-      ]
+      },
+      "pick_protection": false,
+      "promo_tag": false,
+      "promotion_id": null,
+      "refund_allowed_until": null,
+      "result": "pending",
+      "reverted_payouts": {
+        "2": {
+          "amount": 6000,
+          "multiplier": 3
+        }
+      },
+      "ruleset_id": 1,
+      "sport": "NBA1H",
+      "updated_at": "2023-02-16T16:38:38-05:00",
+      "user_id": 1224768,
+      "uuid": null
     },
-    "promotion": {
-      "data": null
+    "relationships": {
+      "predictions": {
+        "data": [
+          {
+            "type": "prediction",
+            "id": "520195535"
+          },
+          {
+            "type": "prediction",
+            "id": "520195536"
+          }
+        ]
+      },
+      "promotion": {
+        "data": null
+      }
     }
+
   }
 }

--- a/test/prizepicks/objects/test_entry.rb
+++ b/test/prizepicks/objects/test_entry.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Project
+  class TestEntry < Minitest::Test
+    def test_entry
+      entry = PrizePicks::Entry.new(read_fixture('entry'))
+      assert_equal 6000, entry.amount_to_win_cents
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,10 @@ module MiniTest
     def stub_response(fixture:, status: 200, headers: { 'Content-Type' => 'application/json' })
       [status, headers, File.read("test/fixtures/#{fixture}.json")]
     end
+
+    def read_fixture(fixture)
+      JSON.parse(File.read("test/fixtures/#{fixture}.json"))
+    end
   end
 end
 


### PR DESCRIPTION
Update the fixture to be under `data`
* Add a test coverage that would have captured this