### PR TITLE
fix: correctly map array response

### DIFF
--- a/lib/prizepicks/objects/base.rb
+++ b/lib/prizepicks/objects/base.rb
@@ -13,7 +13,7 @@ module PrizePicks
     end
 
     def data
-      @resp['data']
+      @resp['data'] || @resp
     end
 
     def to_obstruct(obj)

--- a/test/prizepicks/api/endpoints/test_entries.rb
+++ b/test/prizepicks/api/endpoints/test_entries.rb
@@ -26,6 +26,7 @@ module PrizePicks
           first_entry = resp.data.first
           assert_equal PrizePicks::Entry, first_entry.class
           assert_equal 2000, first_entry.amount_bet_cents
+          assert_equal '134928677', first_entry.data['id']
         end
       end
     end


### PR DESCRIPTION
This will also fix mapping the raw object to `data` so things like `id` can be fetched.