### PR TITLE
feat: member_transactions endpoints

### DIFF
--- a/lib/prizepicks.rb
+++ b/lib/prizepicks.rb
@@ -21,6 +21,7 @@ module PrizePicks
   autoload :Base, 'prizepicks/objects/base'
   autoload :Entry, 'prizepicks/objects/entry'
   autoload :League, 'prizepicks/objects/league'
+  autoload :MemberTransaction, 'prizepicks/objects/member_transaction'
   autoload :Projection, 'prizepicks/objects/projection'
   autoload :User, 'prizepicks/objects/user'
 end

--- a/lib/prizepicks/api/endpoints.rb
+++ b/lib/prizepicks/api/endpoints.rb
@@ -2,6 +2,7 @@
 
 require_relative 'endpoints/entries'
 require_relative 'endpoints/leagues'
+require_relative 'endpoints/member_transactions'
 require_relative 'endpoints/projections'
 require_relative 'endpoints/sign_in'
 
@@ -10,6 +11,7 @@ module PrizePicks
     module Endpoints
       include Entries
       include Leagues
+      include MemberTransactions
       include Projections
       include SignIn
     end

--- a/lib/prizepicks/api/endpoints/member_transactions.rb
+++ b/lib/prizepicks/api/endpoints/member_transactions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module PrizePicks
+  module Api
+    module Endpoints
+      module MemberTransactions
+        ENDPOINT = '/member_transactions'
+
+        def member_transactions(options = {})
+          resp = request(:get, ENDPOINT, options)
+          Collection.from_response(parsed_resp(resp), type: MemberTransaction)
+        end
+
+        def parsed_resp(resp)
+          { 'data' => resp.map { |r| r }, 'included' => [] }
+        end
+      end
+    end
+  end
+end

--- a/lib/prizepicks/objects/member_transaction.rb
+++ b/lib/prizepicks/objects/member_transaction.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module PrizePicks
+  class MemberTransaction < Base
+  end
+end

--- a/test/fixtures/member_transactions.json
+++ b/test/fixtures/member_transactions.json
@@ -1,0 +1,71 @@
+[{
+    "data": {
+      "id": "142077269",
+      "type": "member_transaction",
+      "attributes": {
+        "transaction_type": "entry_won",
+        "amount_cents": 1680,
+        "credit_at_time_cents": 51679,
+        "promo_at_time_cents": 0,
+        "is_promo": false,
+        "created_at": "2023-03-01T21:04:12.912-05:00",
+        "updated_at": "2023-03-01T21:04:12.912-05:00",
+        "object": {
+          "data": {
+            "id": "144876190",
+            "type": "new_wager",
+            "attributes": {
+              "user_id": 1224768,
+              "amount_bet_cents": 560,
+              "amount_won_cents": 1680,
+              "result": "won",
+              "created_at": "2023-03-01T11:23:34.226-05:00",
+              "updated_at": "2023-03-01T21:04:12.932-05:00",
+              "pick_protection": false,
+              "promo_tag": false,
+              "parlay_count": 2,
+              "sport": "CBB",
+              "code": null,
+              "ruleset_id": 1,
+              "is_gift": false,
+              "uuid": null,
+              "payout_multipliers": {
+                "0": 3
+              },
+              "amount_to_win_cents": 1680,
+              "refund_allowed_until": null,
+              "eligible_for_refund": null,
+              "payouts": {
+                "2": {
+                  "amount": 1680,
+                  "multiplier": 3
+                }
+              },
+              "reverted_payouts": {
+                "2": {
+                  "amount": 1680,
+                  "multiplier": 3
+                }
+              },
+              "correlated_entry": false,
+              "alert": null
+            },
+            "relationships": {
+              "predictions": {
+                "data": [
+                  {
+                    "id": "560278898",
+                    "type": "prediction"
+                  },
+                  {
+                    "id": "560278900",
+                    "type": "prediction"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }]

--- a/test/prizepicks/api/endpoints/test_member_transactions.rb
+++ b/test/prizepicks/api/endpoints/test_member_transactions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module PrizePicks
+  module Api
+    module Endpoints
+      class TestMemberTransactions < Minitest::Test
+        def test_member_transactions
+          stub = stub_request(PrizePicks::Api::Endpoints::MemberTransactions::ENDPOINT,
+                              response: stub_response(fixture: 'member_transactions'))
+          client = init_client(stub: stub)
+          resp = client.member_transactions
+          assert_equal PrizePicks::Collection, resp.class
+          assert_equal PrizePicks::MemberTransaction, resp.data.first.class
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It looks like this endpoint needs a `year` and a `month` query paramater.

It should be used like
`client.member_transactions(year: 2022, month: 'August')`