### PR TITLE
feat: client inspect filter

### DIFF
--- a/lib/prizepicks/client.rb
+++ b/lib/prizepicks/client.rb
@@ -17,5 +17,17 @@ module PrizePicks
       @stubs = options[:stubs] || nil
       @adapter = options[:adapter] || nil
     end
+
+    def inspect
+      content = Config::ATTRIBUTES.map do |key|
+        if key == :password
+          "#{key}: [FILTERED]"
+        else
+          "#{key}: #{send(key).inspect}"
+        end
+      end.compact.join(', ')
+
+      "#<#{self.class.name} #{content}>"
+    end
   end
 end

--- a/test/prizepicks/test_client.rb
+++ b/test/prizepicks/test_client.rb
@@ -3,22 +3,15 @@ require 'test_helper'
 
 module PrizePicks
   class TestClient < MiniTest::Test
-    # def test_client_setup_raises_error_without_email
-    #   assert_raises ArgumentError do
-    #     init_client(password: 'foobar')
-    #   end
-    # end
-    #
-    # def test_client_setup_raises_error_without_password
-    #   assert_raises ArgumentError do
-    #     init_client(email: 'foo@foo.com')
-    #   end
-    # end
-
     def test_email
       client = init_client(email: 'foo@foo.com', password: 'foobar')
       assert_equal 'foo@foo.com', client.email
       assert_equal 'foobar', client.password
+    end
+
+    def test_inpsect
+      client = init_client(email: 'foo@foo.com', password: 'foobar')
+      assert_match(/[FILTERED]/, client.inspect)
     end
   end
 end


### PR DESCRIPTION
Currently inspecting the client would show the password, this is not a good idea.

This feature should filter the password on inspect

Closes #5